### PR TITLE
Add server locking.

### DIFF
--- a/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/GenericRedisMessage.java
+++ b/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/GenericRedisMessage.java
@@ -217,6 +217,7 @@ public class GenericRedisMessage {
             if (this.type == PING)              return new RedisMessageServerPing(this.protocolVersion, this.rawMessage, this.privateKey, this.address, this.origin, this.parameters);
             if (this.type == PING_RESPONSE)     return new RedisMessageServerPingResponse(this.protocolVersion, this.rawMessage, this.privateKey, this.address, this.origin, this.parameters);
             if (this.type == SEND_PLAYER)       return new RedisMessageSendPlayer(this.protocolVersion, this.rawMessage, this.privateKey, this.address, this.origin, this.parameters);
+            if (this.type == SEND_LOCK_STATE)       return new RedisMessageServerLockState(this.protocolVersion, this.rawMessage, this.privateKey, this.address, this.origin, this.parameters);
             if (this.type == COORDINATE_REQUEST_QUEUE)  return new RedisMessageCoordinateRequestQueue(this.protocolVersion, this.rawMessage, this.privateKey, this.address, this.origin, this.parameters);
 
             throw new IllegalStateException("Invalid RedisMessage type encountered!");
@@ -243,6 +244,7 @@ public class GenericRedisMessage {
             if(this.type == PING)               return new RedisMessageServerPing(this.address, this.origin, this.parameters);
             if(this.type == PING_RESPONSE)      return new RedisMessageServerPingResponse(this.address, this.origin, this.parameters);
             if(this.type == SEND_PLAYER)        return new RedisMessageSendPlayer(this.address, this.origin, this.parameters);
+            if(this.type == SEND_LOCK_STATE)        return new RedisMessageServerLockState(this.address, this.origin, this.parameters);
             if(this.type == COORDINATE_REQUEST_QUEUE)   return new RedisMessageCoordinateRequestQueue(this.address, this.origin, this.parameters);
 
             throw new IllegalStateException("Invalid RedisMessage type encountered!");

--- a/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/RedisMessageType.java
+++ b/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/RedisMessageType.java
@@ -32,12 +32,18 @@ public class RedisMessageType {
      */
     public static Mapping COORDINATE_REQUEST_QUEUE = new Mapping(300, "TPA_QUEUE_PLAYER");
 
+    /**
+     * `Server > Proxy` | Sets a server's locked state.
+     */
+    public static Mapping SEND_LOCK_STATE = new Mapping(400, "SEND_LOCK_STATE");
+
     public static List<Mapping> toList() {
         List<Mapping> list = new ArrayList<>();
         list.add(PING);
         list.add(PING_RESPONSE);
         list.add(SEND_PLAYER);
         list.add(COORDINATE_REQUEST_QUEUE);
+        list.add(SEND_LOCK_STATE);
 
         return list;
     }

--- a/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/variants/RedisMessageSendPlayer.java
+++ b/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/variants/RedisMessageSendPlayer.java
@@ -73,6 +73,8 @@ public class RedisMessageSendPlayer extends GenericRedisMessage {
         String TARGET_FAMILY_NAME = "f";
         String PLAYER_UUID = "p";
 
+        String LOCK_STATE = "l";
+
         static List<String> toList() {
             List<String> list = new ArrayList<>();
             list.add(TARGET_FAMILY_NAME);

--- a/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/variants/RedisMessageSendPlayer.java
+++ b/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/variants/RedisMessageSendPlayer.java
@@ -73,8 +73,6 @@ public class RedisMessageSendPlayer extends GenericRedisMessage {
         String TARGET_FAMILY_NAME = "f";
         String PLAYER_UUID = "p";
 
-        String LOCK_STATE = "l";
-
         static List<String> toList() {
             List<String> list = new ArrayList<>();
             list.add(TARGET_FAMILY_NAME);

--- a/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/variants/RedisMessageServerLockState.java
+++ b/core/src/main/java/group/aelysium/rustyconnector/core/lib/database/redis/messages/variants/RedisMessageServerLockState.java
@@ -1,0 +1,86 @@
+package group.aelysium.rustyconnector.core.lib.database.redis.messages.variants;
+
+import com.google.gson.JsonObject;
+import com.google.gson.JsonPrimitive;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.GenericRedisMessage;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.MessageOrigin;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.RedisMessageType;
+import io.lettuce.core.KeyValue;
+
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+
+public class RedisMessageServerLockState extends GenericRedisMessage {
+    private boolean lockState;
+
+    private String serverName;
+
+    public boolean lockState() {
+        return lockState;
+    }
+
+    public String serverName() {
+        return serverName;
+    }
+
+    public RedisMessageServerLockState(InetSocketAddress address, MessageOrigin origin, List<KeyValue<String, JsonPrimitive>> parameters) {
+        super(RedisMessageType.SEND_LOCK_STATE, address, origin);
+
+        if(!RedisMessageServerLockState.validateParameters(ValidParameters.toList(), parameters))
+            throw new IllegalStateException("Unable to construct Redis message! There are missing parameters!");
+
+        parameters.forEach(entry -> {
+            String key = entry.getKey();
+            JsonPrimitive value = entry.getValue();
+
+            switch (key) {
+                case ValidParameters.SERVER_NAME -> this.serverName = value.getAsString();
+                case ValidParameters.LOCK_STATE -> this.lockState = value.getAsBoolean();
+            }
+        });
+    }
+    public RedisMessageServerLockState(int messageVersion, String rawMessage, char[] privateKey, InetSocketAddress address, MessageOrigin origin, List<KeyValue<String, JsonPrimitive>> parameters) {
+        super(messageVersion, rawMessage, privateKey, RedisMessageType.SEND_LOCK_STATE, address, origin);
+
+        if(!RedisMessageServerLockState.validateParameters(ValidParameters.toList(), parameters))
+            throw new IllegalStateException("Unable to construct Redis message! There are missing parameters!");
+
+        parameters.forEach(entry -> {
+            String key = entry.getKey();
+            JsonPrimitive value = entry.getValue();
+
+            switch (key) {
+                case ValidParameters.SERVER_NAME -> this.serverName = value.getAsString();
+                case ValidParameters.LOCK_STATE -> this.lockState = value.getAsBoolean();
+            }
+        });
+    }
+
+    @Override
+    public JsonObject toJSON() {
+        JsonObject object = super.toJSON();
+        JsonObject parameters = new JsonObject();
+
+        parameters.add(ValidParameters.SERVER_NAME, new JsonPrimitive(this.serverName));
+        parameters.add(ValidParameters.LOCK_STATE, new JsonPrimitive(this.lockState));
+
+        object.add(MasterValidParameters.PARAMETERS, parameters);
+
+        return object;
+    }
+
+    public interface ValidParameters {
+        String LOCK_STATE = "l";
+
+        String SERVER_NAME = "n";
+
+        static List<String> toList() {
+            List<String> list = new ArrayList<>();
+            list.add(LOCK_STATE);
+            list.add(SERVER_NAME);
+
+            return list;
+        }
+    }
+}

--- a/paper/src/main/java/group/aelysium/rustyconnector/plugin/paper/lib/services/RedisMessagerService.java
+++ b/paper/src/main/java/group/aelysium/rustyconnector/plugin/paper/lib/services/RedisMessagerService.java
@@ -4,6 +4,7 @@ import group.aelysium.rustyconnector.core.lib.database.redis.messages.GenericRed
 import group.aelysium.rustyconnector.core.lib.database.redis.messages.MessageOrigin;
 import group.aelysium.rustyconnector.core.lib.database.redis.messages.RedisMessageType;
 import group.aelysium.rustyconnector.core.lib.database.redis.messages.variants.RedisMessageSendPlayer;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.variants.RedisMessageServerLockState;
 import group.aelysium.rustyconnector.core.lib.database.redis.messages.variants.RedisMessageServerPing;
 import group.aelysium.rustyconnector.core.lib.lang_messaging.Lang;
 import group.aelysium.rustyconnector.core.lib.serviceable.Service;
@@ -52,6 +53,24 @@ public class RedisMessagerService extends Service {
                 .setAddress(serverInfoService.address())
                 .setParameter(RedisMessageSendPlayer.ValidParameters.TARGET_FAMILY_NAME, familyName)
                 .setParameter(RedisMessageSendPlayer.ValidParameters.PLAYER_UUID, player.getUniqueId().toString())
+                .buildSendable();
+
+        api.services().redisService().publish(message);
+    }
+
+    /**
+     * @param lockState Sets whether the server should be locked or not.
+     */
+    public void setLockState(String serverName, boolean lockState) {
+        PaperAPI api = PaperAPI.get();
+        ServerInfoService serverInfoService = api.services().serverInfoService();
+
+        RedisMessageServerLockState message = (RedisMessageServerLockState) new GenericRedisMessage.Builder()
+                .setType(RedisMessageType.SEND_LOCK_STATE)
+                .setOrigin(MessageOrigin.SERVER)
+                .setAddress(serverInfoService.address())
+                .setParameter(RedisMessageServerLockState.ValidParameters.SERVER_NAME, serverName)
+                .setParameter(RedisMessageServerLockState.ValidParameters.LOCK_STATE, String.valueOf(lockState))
                 .buildSendable();
 
         api.services().redisService().publish(message);

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/database/RedisSubscriber.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/database/RedisSubscriber.java
@@ -84,6 +84,7 @@ public class RedisSubscriber extends group.aelysium.rustyconnector.core.lib.data
         try {
             if(message.type() == PING)           new MagicLinkPingHandler(message).execute();
             if(message.type() == SEND_PLAYER)    new SendPlayerHandler(message).execute();
+            if(message.type() == SEND_LOCK_STATE)    new SetServerLockStateHandler(message).execute();
 
             cachedMessage.sentenceMessage(MessageStatus.EXECUTED);
         } catch (NullPointerException e) {

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/family/ScalarServerFamily.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/family/ScalarServerFamily.java
@@ -163,8 +163,10 @@ class ScalarFamilyConnector {
     private PlayerServer connectSingleton() {
         PlayerServer server = this.family.loadBalancer().current(); // Get the server that is currently listed as highest priority
         try {
-            if(!server.validatePlayer(player))
-                throw new RuntimeException("The server you're trying to connect to is full!");
+            if(!server.validatePlayer(player)) {
+                if (!server.locked()) throw new RuntimeException("The server you're trying to connect to is full!");
+                else throw new RuntimeException("The server you're trying to connect to is locked!");
+            }
 
             if(this.event == null) {
                 if (!server.connect(player))
@@ -190,8 +192,10 @@ class ScalarFamilyConnector {
             PlayerServer server = this.family.loadBalancer().current(); // Get the server that is currently listed as highest priority
 
             try {
-                if(!server.validatePlayer(player))
-                    throw new RuntimeException("The server you're trying to connect to is full!");
+                if(!server.validatePlayer(player)) {
+                    if (!server.locked()) throw new RuntimeException("The server you're trying to connect to is full!");
+                    else throw new RuntimeException("The server you're trying to connect to is locked!");
+                }
 
                 if(this.event == null) {
                     if (server.connect(player)) {

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/family/StaticServerFamily.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/family/StaticServerFamily.java
@@ -327,8 +327,10 @@ class StaticFamilyConnector {
     private PlayerServer connectSingleton() {
         PlayerServer server = this.family.loadBalancer().current();
         try {
-            if(!server.validatePlayer(this.player))
-                throw new RuntimeException("The server you're trying to connect to is full!");
+            if(!server.validatePlayer(this.player)) {
+                if (!server.locked()) throw new RuntimeException("The server you're trying to connect to is full!");
+                else throw new RuntimeException("The server you're trying to connect to is locked!");
+            }
 
             if (!server.connect(this.player))
                 throw new RuntimeException("There was an issue connecting you to the server!");
@@ -349,8 +351,10 @@ class StaticFamilyConnector {
             PlayerServer server = this.family.loadBalancer().current(); // Get the server that is currently listed as highest priority
 
             try {
-                if (!server.validatePlayer(this.player))
-                    throw new RuntimeException("The server you're trying to connect to is full!");
+                if (!server.validatePlayer(this.player)) {
+                    if (!server.locked()) throw new RuntimeException("The server you're trying to connect to is full!");
+                    else throw new RuntimeException("The server you're trying to connect to is locked!");
+                }
 
                 if (server.connect(this.player)) {
                     this.family.loadBalancer().forceIterate();

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/lang_messaging/VelocityLang.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/lang_messaging/VelocityLang.java
@@ -212,7 +212,7 @@ public interface VelocityLang extends Lang {
                         servers = servers.append(
                                 text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
                                                 "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
-                                                "["+server.playerCount()+" (XXX <> XXX) w-"+server.weight()+"] <<<<<"
+                                                "["+server.playerCount()+" (XX <> XX) w-"+server.weight()+"] <<<<<"
                                         , GREEN));
                     } else {
                         servers = servers.append(
@@ -226,7 +226,7 @@ public interface VelocityLang extends Lang {
                         servers = servers.append(
                                 text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
                                                 "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
-                                                "["+server.playerCount()+" (XXX <> XXX) w-"+server.weight()+"]"
+                                                "["+server.playerCount()+" (XX <> XX) w-"+server.weight()+"]"
                                         , GRAY));
                     } else {
                         servers = servers.append(

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/lang_messaging/VelocityLang.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/lang_messaging/VelocityLang.java
@@ -208,17 +208,33 @@ public interface VelocityLang extends Lang {
         else if(family.registeredServers().size() == 0) servers = text("There are no registered servers.", DARK_GRAY);
         else for (PlayerServer server : family.registeredServers()) {
                 if(family.loadBalancer().index() == i)
-                    servers = servers.append(
-                            text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
-                                            "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
-                                            "["+server.playerCount()+" ("+server.softPlayerCap()+" <> "+server.hardPlayerCap()+") w-"+server.weight()+"] <<<<<"
-                                    , GREEN));
+                    if (server.locked()) {
+                        servers = servers.append(
+                                text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
+                                                "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
+                                                "["+server.playerCount()+" (XXX <> XXX) w-"+server.weight()+"] <<<<<"
+                                        , GREEN));
+                    } else {
+                        servers = servers.append(
+                                text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
+                                                "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
+                                                "["+server.playerCount()+" ("+server.softPlayerCap()+" <> "+server.hardPlayerCap()+") w-"+server.weight()+"] <<<<<"
+                                        , GREEN));
+                    }
                 else
-                    servers = servers.append(
-                            text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
-                                            "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
-                                            "["+server.playerCount()+" ("+server.softPlayerCap()+" <> "+server.hardPlayerCap()+") w-"+server.weight()+"]"
-                                    , GRAY));
+                    if (server.locked()) {
+                        servers = servers.append(
+                                text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
+                                                "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
+                                                "["+server.playerCount()+" (XXX <> XXX) w-"+server.weight()+"]"
+                                        , GRAY));
+                    } else {
+                        servers = servers.append(
+                                text("   ---| "+(i + 1)+". ["+server.registeredServer().getServerInfo().getName()+"]" +
+                                                "("+ AddressUtil.addressToString(server.registeredServer().getServerInfo().getAddress()) +") " +
+                                                "["+server.playerCount()+" ("+server.softPlayerCap()+" <> "+server.hardPlayerCap()+") w-"+server.weight()+"]"
+                                        , GRAY));
+                    }
 
                 servers = servers.append(newline());
 

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/message/handling/SetServerLockStateHandler.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/message/handling/SetServerLockStateHandler.java
@@ -1,0 +1,34 @@
+package group.aelysium.rustyconnector.plugin.velocity.lib.message.handling;
+
+import com.velocitypowered.api.proxy.server.RegisteredServer;
+import com.velocitypowered.api.proxy.server.ServerInfo;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.GenericRedisMessage;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.MessageHandler;
+import group.aelysium.rustyconnector.core.lib.database.redis.messages.variants.RedisMessageServerLockState;
+import group.aelysium.rustyconnector.plugin.velocity.central.VelocityAPI;
+import group.aelysium.rustyconnector.plugin.velocity.lib.family.FamilyService;
+import group.aelysium.rustyconnector.plugin.velocity.lib.family.bases.BaseServerFamily;
+import group.aelysium.rustyconnector.plugin.velocity.lib.family.bases.PlayerFocusedServerFamily;
+import group.aelysium.rustyconnector.plugin.velocity.lib.server.PlayerServer;
+
+import java.util.List;
+
+public class SetServerLockStateHandler implements MessageHandler {
+    private final RedisMessageServerLockState message;
+
+    public SetServerLockStateHandler(GenericRedisMessage message) {
+        this.message = (RedisMessageServerLockState) message;
+    }
+
+    @Override
+    public void execute() throws Exception {
+        VelocityAPI api = VelocityAPI.get();
+
+        try {
+            ServerInfo serverInfo = api.velocityServer().getServer(this.message.serverName()).get().getServerInfo();
+            api.services().serverService().search(serverInfo).setLocked(this.message.lockState());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/server/PlayerServer.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/server/PlayerServer.java
@@ -27,6 +27,8 @@ public class PlayerServer implements group.aelysium.rustyconnector.core.lib.mode
     private int weight;
     private int softPlayerCap;
     private int hardPlayerCap;
+    
+    private boolean isLocked = false;
 
     private AtomicInteger timeout;
 
@@ -116,12 +118,28 @@ public class PlayerServer implements group.aelysium.rustyconnector.core.lib.mode
 
 
     /**
+     * Checks if the server is locked, meaning players cannot be
+     * put into the server when sent to the family.
+     *
+     * @return `false` if players are able to join the server, otherwise `true`.
+     */
+    public boolean locked() { return this.isLocked; }
+
+    /**
+     * @param lockState Sets whether the server is locked or unlocked.
+     */
+
+    public void setLocked(boolean lockState) {this.isLocked = lockState; }
+
+    /**
      * Validates the player against the server's current player count.
      * If the server is full or the player doesn't have permissions to bypass soft and hard player caps. They will be kicked
      * @param player The player to validate
      * @return `true` if the player is able to join. `false` otherwise.
      */
     public boolean validatePlayer(Player player) {
+        if (this.locked()) return false;
+
         if(Permission.validate(
                 player,
                 "rustyconnector.hardCapBypass",

--- a/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/server/PlayerServer.java
+++ b/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/server/PlayerServer.java
@@ -138,8 +138,6 @@ public class PlayerServer implements group.aelysium.rustyconnector.core.lib.mode
      * @return `true` if the player is able to join. `false` otherwise.
      */
     public boolean validatePlayer(Player player) {
-        if (this.locked()) return false;
-
         if(Permission.validate(
                 player,
                 "rustyconnector.hardCapBypass",
@@ -154,7 +152,15 @@ public class PlayerServer implements group.aelysium.rustyconnector.core.lib.mode
                 Permission.constructNode("rustyconnector.<family name>.softCapBypass",this.family.name())
         )) return true; // If the player has permission to bypass soft-player-cap, let them in.
 
-        return !this.full();
+        if(this.full()) return false; // If the player count is at soft-player-cap. Boot the player.
+
+        if(Permission.validate(
+                player,
+                "rustyconnector.lockBypass",
+                Permission.constructNode("rustyconnector.<family name>.lockBypass",this.family.name())
+        )) return true; // If the player has permission to bypass the server lock, let them in.
+
+        return !this.locked(); // If the server is locked, boot the player, otherwise let them in.
     }
 
     @Override


### PR DESCRIPTION
This is mostly useful for minigames where you may still want to be able to connect to  the server as an admin and/or see the total player count in a family including started games, but don't want players to be put into the server after the game starts.

Currently adds:
- SEND_LOCK_STATE message type
- `/rc lock` and `/rc unlock` on the paper side.
- Fancy formatting for locked servers in /rc family (aka just replaces the number with x's)

TODO:
- [ ] Have locked servers be skipped by load balancers.
- [x] Make naming of the new RedisMessage more consistent
- [x] Add permission to bypass lock
- [x] Add separate "Server is locked" and "Server is full" messages.

Once the TODOs are done I'll undraft this, until then feel free to give feedback on implementation/naming.