### PR TITLE
Make entering a queue have a player rejoin their active session.

### DIFF
--- a/plugin/core/src/main/resources/en_us/configs/proxy/matchmakers/matchmaker.yml
+++ b/plugin/core/src/main/resources/en_us/configs/proxy/matchmakers/matchmaker.yml
@@ -80,7 +80,14 @@ max: 10
 #
 variance: 0.2
 
+#
+# Whether a player should be reconnected to their previous session if
+# it's still running when they try to join the queue.
+#
+# If false, the player will be put into queue for a new session instead.
+#
 
+reconnect: true
 
 #
 # A LiquidTimestamp representing how often the matchmaker should review its waiting players and attempt to build a match.

--- a/plugin/toolkit/src/main/java/group/aelysium/rustyconnector/toolkit/velocity/matchmaking/matchmakers/IMatchmaker.java
+++ b/plugin/toolkit/src/main/java/group/aelysium/rustyconnector/toolkit/velocity/matchmaking/matchmakers/IMatchmaker.java
@@ -79,6 +79,7 @@ public interface IMatchmaker extends Service {
             int min,
             int max,
             double variance,
+            boolean reconnect,
             LiquidTimestamp interval
     ) {}
 }

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/config/configs/MatchMakerConfig.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/config/configs/MatchMakerConfig.java
@@ -21,6 +21,8 @@ public class MatchMakerConfig extends YAML implements group.aelysium.rustyconnec
     private LiquidTimestamp matchmakingInterval;
     private double variance;
 
+    private boolean reconnect;
+
     public IScoreCard.IRankSchema.Type<?> getAlgorithm() {
         return algorithm;
     }
@@ -36,6 +38,8 @@ public class MatchMakerConfig extends YAML implements group.aelysium.rustyconnec
     public double getVariance() {
         return variance;
     }
+
+    public boolean reconnect() { return reconnect; }
 
     protected MatchMakerConfig(Path dataFolder, String target, String name, LangService lang) {
         super(dataFolder, target, name, lang, LangFileMappings.PROXY_MATCHMAKER_TEMPLATE);
@@ -54,6 +58,8 @@ public class MatchMakerConfig extends YAML implements group.aelysium.rustyconnec
 
         this.min = IYAML.getValue(this.data,"min",Integer.class);
         this.max = IYAML.getValue(this.data,"max",Integer.class);
+
+        this.reconnect = IYAML.getValue(this.data, "reconnect", Boolean.class);
 
         try {
             this.matchmakingInterval = LiquidTimestamp.from(IYAML.getValue(this.data, "matchmaking-interval", String.class));

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/family/ranked_family/RankedFamily.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/family/ranked_family/RankedFamily.java
@@ -112,7 +112,7 @@ public class RankedFamily extends Family implements IRankedFamily {
 
                 fetched = Optional.of(game);
             }
-            IMatchmaker.Settings matchmakerSettings = new IMatchmaker.Settings(mySQLStorage, matchMakerConfig.getAlgorithm(), fetched.orElseThrow(), matchMakerConfig.min(), matchMakerConfig.max(), matchMakerConfig.getVariance(), matchMakerConfig.getMatchmakingInterval());
+            IMatchmaker.Settings matchmakerSettings = new IMatchmaker.Settings(mySQLStorage, matchMakerConfig.getAlgorithm(), fetched.orElseThrow(), matchMakerConfig.min(), matchMakerConfig.max(), matchMakerConfig.getVariance(), matchMakerConfig.reconnect(), matchMakerConfig.getMatchmakingInterval());
 
             matchmaker = Matchmaker.from(matchmakerSettings);
         }

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
@@ -70,6 +70,17 @@ public abstract class Matchmaker implements IMatchmaker {
         try {
             IRankedPlayer rankedPlayer = this.settings.game().rankedPlayer(this.settings.storage(), request.player().uuid(), false);
 
+            if (true) { // TODO: Replace this with config option
+                 for (ISession session : this.runningSessions.values().stream().toList()) {
+                     for (IPlayer player : session.players()) {
+                         if (player.uuid() == rankedPlayer.uuid()) {
+                             session.mcLoader().connect(player);
+                             return;
+                         }
+                     }
+                 }
+            }
+
             if(this.waitingPlayers.contains(rankedPlayer)) throw new RuntimeException("Player is already queued!");
 
             this.waitingPlayers.add(rankedPlayer);

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
@@ -73,7 +73,7 @@ public abstract class Matchmaker implements IMatchmaker {
             if (this.settings.reconnect()) {
                  for (ISession session : this.runningSessions.values().stream().toList()) {
                      for (IPlayer player : session.players()) {
-                         if (player.uuid() == rankedPlayer.uuid()) {
+                         if (player.uuid().equals(rankedPlayer.uuid())) {
                              session.mcLoader().connect(player);
                              result.complete(ConnectionResult.success(Component.text("You've been reconnected to your game."), session.mcLoader()));
                              return;

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
@@ -75,6 +75,7 @@ public abstract class Matchmaker implements IMatchmaker {
                      for (IPlayer player : session.players()) {
                          if (player.uuid() == rankedPlayer.uuid()) {
                              session.mcLoader().connect(player);
+                             result.complete(ConnectionResult.success(Component.text("You've been reconnected to your game."), session.mcLoader()));
                              return;
                          }
                      }

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Matchmaker.java
@@ -70,7 +70,7 @@ public abstract class Matchmaker implements IMatchmaker {
         try {
             IRankedPlayer rankedPlayer = this.settings.game().rankedPlayer(this.settings.storage(), request.player().uuid(), false);
 
-            if (true) { // TODO: Replace this with config option
+            if (this.settings.reconnect()) {
                  for (ISession session : this.runningSessions.values().stream().toList()) {
                      for (IPlayer player : session.players()) {
                          if (player.uuid() == rankedPlayer.uuid()) {

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
@@ -31,6 +31,7 @@ public class Randomized extends Matchmaker {
                     for (IPlayer player : session.players()) {
                         if (player.uuid() == rankedPlayer.uuid()) {
                             session.mcLoader().connect(player);
+                            result.complete(ConnectionResult.success(Component.text("You've been reconnected to your game."), session.mcLoader()));
                             return;
                         }
                     }

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
@@ -29,7 +29,7 @@ public class Randomized extends Matchmaker {
             if (this.settings.reconnect()) {
                 for (ISession session : this.runningSessions.values().stream().toList()) {
                     for (IPlayer player : session.players()) {
-                        if (player.uuid() == rankedPlayer.uuid()) {
+                        if (player.uuid().equals(rankedPlayer.uuid())) {
                             session.mcLoader().connect(player);
                             result.complete(ConnectionResult.success(Component.text("You've been reconnected to your game."), session.mcLoader()));
                             return;

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
@@ -26,7 +26,7 @@ public class Randomized extends Matchmaker {
         try {
             IRankedPlayer rankedPlayer = new RankedPlayer(request.player().uuid(), new RandomizedPlayerRank());
 
-            if (true) { // TODO: Replace this with config option
+            if (this.settings.reconnect()) {
                 for (ISession session : this.runningSessions.values().stream().toList()) {
                     for (IPlayer player : session.players()) {
                         if (player.uuid() == rankedPlayer.uuid()) {

--- a/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
+++ b/plugin/velocity/src/main/java/group/aelysium/rustyconnector/plugin/velocity/lib/matchmaking/matchmakers/Randomized.java
@@ -6,7 +6,9 @@ import group.aelysium.rustyconnector.plugin.velocity.lib.matchmaking.storage.Ran
 import group.aelysium.rustyconnector.plugin.velocity.lib.matchmaking.storage.player_rank.RandomizedPlayerRank;
 import group.aelysium.rustyconnector.toolkit.velocity.connection.ConnectionResult;
 import group.aelysium.rustyconnector.toolkit.velocity.connection.PlayerConnectable;
+import group.aelysium.rustyconnector.toolkit.velocity.matchmaking.gameplay.ISession;
 import group.aelysium.rustyconnector.toolkit.velocity.matchmaking.storage.IRankedPlayer;
+import group.aelysium.rustyconnector.toolkit.velocity.player.IPlayer;
 import net.kyori.adventure.text.Component;
 
 import java.util.ArrayList;
@@ -23,6 +25,17 @@ public class Randomized extends Matchmaker {
     public void add(PlayerConnectable.Request request, CompletableFuture<ConnectionResult> result) {
         try {
             IRankedPlayer rankedPlayer = new RankedPlayer(request.player().uuid(), new RandomizedPlayerRank());
+
+            if (true) { // TODO: Replace this with config option
+                for (ISession session : this.runningSessions.values().stream().toList()) {
+                    for (IPlayer player : session.players()) {
+                        if (player.uuid() == rankedPlayer.uuid()) {
+                            session.mcLoader().connect(player);
+                            return;
+                        }
+                    }
+                }
+            }
 
             if(this.waitingPlayers.contains(rankedPlayer)) throw new RuntimeException("Player is already queued!");
 


### PR DESCRIPTION
This adds a config option to make it so that if a player leaves their ranked server for whatever reason then tries to requeue for the same ranked family, it'll send them back to their session assuming it's still active.